### PR TITLE
Fix tuff block metadata handling

### DIFF
--- a/src/main/java/kamkeel/plugin/Blocks/ItemBlock/ItemBlockEnum.java
+++ b/src/main/java/kamkeel/plugin/Blocks/ItemBlock/ItemBlockEnum.java
@@ -14,10 +14,19 @@ public class ItemBlockEnum<E extends Enum<E>> extends ItemBlock {
         super(block);
         this.enumClass = enumClass;
         this.blockPrefix = blockPrefix;
+
+        // Ensure this ItemBlock keeps metadata for each variant
+        this.setHasSubtypes(true);
+        this.setMaxDamage(0);
     }
 
     @Override
     public int getMetadata(int meta) {
+        // Clamp the metadata to valid bounds. This prevents out of range
+        // values from dropping incorrect variants.
+        if (meta < 0 || meta >= enumClass.getEnumConstants().length) {
+            return 0;
+        }
         return meta;
     }
 


### PR DESCRIPTION
## Summary
- ensure item blocks keep metadata for variant blocks like tuff
- clamp invalid metadata to 0

## Testing
- `./gradlew build -x test` *(fails: BlockBarrel errors)*

------
https://chatgpt.com/codex/tasks/task_e_688124d12b688323bda2ef2324b55e92